### PR TITLE
[Hotfix] cached refresh

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           secret-ids: |  # Replace ARNs with your own
             UD, arn:aws:secretsmanager:af-south-1:678681925278:secret:aaq-template-ud-secrets-KQ82bP
-            GH, arn:aws:secretsmanager:af-south-1:678681925278:secret:github_machine_user_token-YPuBjA
           parse-json-secrets: true
       - name: Build Docker image
         run: |
@@ -35,7 +34,6 @@ jobs:
           docker build --rm \
             --build-arg NAME=${IMAGE_NAME} \
             --build-arg PORT=9904 \
-            --build-arg TOKEN_MACHINE_USER=${{ env.GH_TOKEN_MACHINE_USER }} \
             -t ${IMAGE_NAME}:${VERSION} \
             ./core_model
       - name: Login to Amazon ECR

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - hotfix-cached-refresh
 
 jobs:
   UpdateDevContainer:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - hotfix-cached-refresh
 
 jobs:
   UpdateDevContainer:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -27,20 +27,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Get AWS secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
-        with:
-          secret-ids: |  # Replace ARNs with your own
-            GH, arn:aws:secretsmanager:af-south-1:678681925278:secret:github_machine_user_token-YPuBjA
-          parse-json-secrets: true
-
       - name: Build Docker image
         run: |
           cp ./requirements.txt ./core_model/requirements.txt
           docker build --rm \
             --build-arg NAME=${{ github.event.repository.name }} \
             --build-arg PORT=9904 \
-            --build-arg TOKEN_MACHINE_USER=${{ env.GH_TOKEN_MACHINE_USER }} \
             -t $IMAGE_NAME \
             ./core_model
       

--- a/.github/workflows/validation-test.yml
+++ b/.github/workflows/validation-test.yml
@@ -35,7 +35,6 @@ jobs:
           secret-ids: |  # Replace ARNs with your own
             UD, arn:aws:secretsmanager:af-south-1:678681925278:secret:aaq-template-ud-secrets-KQ82bP
             GLOBAL, arn:aws:secretsmanager:af-south-1:678681925278:secret:aaq-template-global-secrets-HEQCSO
-            GH, arn:aws:secretsmanager:af-south-1:678681925278:secret:github_machine_user_token-YPuBjA
           parse-json-secrets: true
 
       - name: Install libraries
@@ -48,7 +47,6 @@ jobs:
           nltk.download('punkt')
           EOF`
           python -c "$nltkdownload"
-          pip install git+https://${{ env.GH_TOKEN_MACHINE_USER }}@github.com/IDinsight/faqt.git@v1.1.1
       - name: Run Unit Tests
         env:
           PG_ENDPOINT: ${{env.GLOBAL_PG_ENDPOINT}}

--- a/core_model/app/__init__.py
+++ b/core_model/app/__init__.py
@@ -164,7 +164,7 @@ def refresh_rule_based_model_cached(app):
         """Wrapper to cache refresh_rules"""
         return refresh_rule_based_model(app)
 
-    def get_ttl_hash(seconds=30):  # TODO: update seconds
+    def get_ttl_hash(seconds=900):  # TODO: update seconds
         """Return the same value within `seconds` time period"""
         return round(time.time() // seconds)
 

--- a/core_model/app/main/inbound.py
+++ b/core_model/app/main/inbound.py
@@ -9,6 +9,7 @@ from flask import current_app, request
 from flask_restx import Resource
 from sqlalchemy.orm.attributes import flag_modified
 
+from .. import refresh_rule_based_model_cached
 from ..data_models import Inbound
 from ..database_sqlalchemy import db
 from ..prometheus_metrics import metrics
@@ -58,6 +59,8 @@ class UrgencyCheck(Resource):
         See class docstring for details.
         """
         received_ts = datetime.utcnow()
+
+        n_rules = refresh_rule_based_model_cached(current_app)
 
         incoming = request.json
         if "metadata" in incoming:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ sentry-sdk[flask]==1.5.12
 itsdangerous==2.0.1
 prometheus-flask-exporter==0.20.1
 SQLAlchemy==1.4.37
+faqt @ git+https://github.com/IDinsight/faqt.git@v1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ flask==2.1.1
 gunicorn==20.1.0
 nltk==3.7
 numpy==1.22.2
-pandas==1.4.2
+pandas>=1.2.3
 psycopg2-binary==2.8.6
 pyyaml==5.4.1
 scipy==1.8.0


### PR DESCRIPTION
Reviewer: @lickem22 
Estimate: 1 hour

# [Hotfix] cached refresh

## Ticket

No tickets -- this is a hotfix.

## Description, Motivation and Context
Problem: we would update an FAQ or UD rule, and the same request would give us different responses — ones reflecting the content update vs. ones that didn’t.

Cause: we use gunicorn workers to run the app, but when we hit the endpoints for updating FAQs, UD rules, or language contextualization configs, this update is made only in one of the workers. So depending on which worker handles the next /inbound/check request, you will get inconsistent results.



## How Has This Been Tested?

## To-do before merge

- [ ] Update periodicity (seconds) in cached refresh functions (e.g. to 3600) 

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [ ] My code follows the style guidelines of this project
- [ ] I have reviewed my own code to ensure good quality
- [ ] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts
- [ ] I have updated the automated tests (if applicable)
- [ ] I have written [good commit messages][1]
- [ ] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/
